### PR TITLE
Refactor TwitterScraper class to follow single-responsibility principle

### DIFF
--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -41,13 +41,3 @@ def logout(user_identifier=Depends(operator_auth_handler.auth_wrapper)):
     resp = Response()
     resp.delete_cookie("access_token")
     return resp
-
-
-# NOTE: for normal user to get their session token
-@router.get("/session-id", name="user:login")
-def get_user_session_id():
-    session_id = user_auth_handler.encode_token()
-    resp = Response()
-    # NOTE: age is 1 year cause we don't wanna user to keep changing ID
-    resp.set_cookie("session_id", session_id, max_age=31556952)
-    return resp

--- a/app/api/scraper.py
+++ b/app/api/scraper.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Depends, HTTPException
 
 from app import schemas
 from app.core.config import settings
-from app.models import TwitterUser
+from app.models import Tweet, TwitterUser
 from app.services.ml import ML
 from app.services.scrape import TwitterScraper
 
@@ -30,7 +30,10 @@ def user_info_check(
     if user_db is None:
         _logger.info("This account is not exist in DB")
         user = scraper.get_user_by_username(username)
-        recent_tweets = scraper.get_tweet_info(user.id_str, settings.TWEETS_NUMBER)
+        recent_tweets = [
+            Tweet(tweet_id=str(tweet.id), text=tweet.text, created_at=tweet.created_at)
+            for tweet in scraper.get_tweet_info(user.id_str, settings.TWEETS_NUMBER)
+        ]
         user_db = TwitterUser(
             twitter_id=user.id_str,
             name=user.name,

--- a/app/api/scraper.py
+++ b/app/api/scraper.py
@@ -3,9 +3,6 @@ import logging
 from fastapi import APIRouter, Depends, HTTPException
 
 from app import schemas
-from app.core.config import settings
-from app.models import Tweet, TwitterUser
-from app.services.ml import ML
 from app.services.scrape import TwitterScraper
 
 _logger = logging.getLogger(__name__)
@@ -14,7 +11,7 @@ router = APIRouter()
 
 @router.get("/check", response_model=schemas.CheckResponse, name="user:get-data")
 def user_info_check(
-    url: str, scraper: TwitterScraper = Depends(), ml_service: ML = Depends()
+    url: str, scraper: TwitterScraper = Depends()
 ) -> schemas.CheckResponse:
     # Validate input url
     if url[:20] == "https://twitter.com/":
@@ -26,28 +23,7 @@ def user_info_check(
     else:
         raise HTTPException(status_code=400, detail="'url' argument is invalid!")
 
-    user_db: TwitterUser = TwitterUser.objects(username=username).first()
-    if user_db is None:
-        _logger.info("This account is not exist in DB")
-        user = scraper.get_user_by_username(username)
-        recent_tweets = [
-            Tweet(tweet_id=str(tweet.id), text=tweet.text, created_at=tweet.created_at)
-            for tweet in scraper.get_tweet_info(user.id_str, settings.TWEETS_NUMBER)
-        ]
-        user_db = TwitterUser(
-            twitter_id=user.id_str,
-            name=user.name,
-            username=user.screen_name,
-            created_at=user.created_at,
-            followers_count=user.followers_count,
-            followings_count=user.friends_count,
-            verified=user.verified,
-            avatar=user.profile_image_url,
-            banner=getattr(user, "profile_banner_url", None),
-            tweets=recent_tweets,
-            score=ml_service.get_analysis_result(user.screen_name),
-        )
-        user_db.save()
+    user_db = scraper.get_user_by_username(username)
 
     response = schemas.CheckResponse(
         score=user_db.score, user_info=user_db.to_response()
@@ -67,8 +43,7 @@ def user_detail_check(url: str, scraper: TwitterScraper = Depends()):
     else:
         raise HTTPException(status_code=400, detail="'url' argument is invalid!")
 
-    user_resp = user_info_check(username)
-    user_db: TwitterUser = TwitterUser.objects(username=username).first()
+    user_db = scraper.get_user_by_username(username)
 
     recent_tweets = user_db.tweets
     recent_tweets_response = [tweet.to_response() for tweet in recent_tweets]
@@ -81,6 +56,6 @@ def user_detail_check(url: str, scraper: TwitterScraper = Depends()):
     )
 
     response = schemas.DetailResponse(
-        user_info=user_resp.user_info, tweet_info=tweet_info, score=user_resp.score
+        user_info=user_db.to_response(), tweet_info=tweet_info, score=user_db.score
     )
     return response

--- a/app/api/scraper.py
+++ b/app/api/scraper.py
@@ -1,11 +1,8 @@
-import logging
-
 from fastapi import APIRouter, Depends, HTTPException
 
 from app import schemas
 from app.services.scrape import TwitterScraper
 
-_logger = logging.getLogger(__name__)
 router = APIRouter()
 
 

--- a/app/api/scraper.py
+++ b/app/api/scraper.py
@@ -1,13 +1,21 @@
+import logging
+
 from fastapi import APIRouter, Depends, HTTPException
 
 from app import schemas
+from app.core.config import settings
+from app.models import TwitterUser
+from app.services.ml import ML
 from app.services.scrape import TwitterScraper
 
+_logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
 @router.get("/check", response_model=schemas.CheckResponse, name="user:get-data")
-def user_info_check(url: str, scraper: TwitterScraper = Depends()):
+def user_info_check(
+    url: str, scraper: TwitterScraper = Depends(), ml_service: ML = Depends()
+) -> schemas.CheckResponse:
     # Validate input url
     if url[:20] == "https://twitter.com/":
         username = url.split("/")[3]
@@ -18,7 +26,25 @@ def user_info_check(url: str, scraper: TwitterScraper = Depends()):
     else:
         raise HTTPException(status_code=400, detail="'url' argument is invalid!")
 
-    user_db = scraper.get_user_by_username(username)
+    user_db: TwitterUser = TwitterUser.objects(username=username).first()
+    if user_db is None:
+        _logger.info("This account is not exist in DB")
+        user = scraper.get_user_by_username(username)
+        recent_tweets = scraper.get_tweet_info(user.id_str, settings.TWEETS_NUMBER)
+        user_db = TwitterUser(
+            twitter_id=user.id_str,
+            name=user.name,
+            username=user.screen_name,
+            created_at=user.created_at,
+            followers_count=user.followers_count,
+            followings_count=user.friends_count,
+            verified=user.verified,
+            avatar=user.profile_image_url,
+            banner=getattr(user, "profile_banner_url", None),
+            tweets=recent_tweets,
+            score=ml_service.get_analysis_result(user.screen_name),
+        )
+        user_db.save()
 
     response = schemas.CheckResponse(
         score=user_db.score, user_info=user_db.to_response()
@@ -38,7 +64,8 @@ def user_detail_check(url: str, scraper: TwitterScraper = Depends()):
     else:
         raise HTTPException(status_code=400, detail="'url' argument is invalid!")
 
-    user_db = scraper.get_user_by_username(username)
+    user_resp = user_info_check(username)
+    user_db: TwitterUser = TwitterUser.objects(username=username).first()
 
     recent_tweets = user_db.tweets
     recent_tweets_response = [tweet.to_response() for tweet in recent_tweets]
@@ -51,6 +78,6 @@ def user_detail_check(url: str, scraper: TwitterScraper = Depends()):
     )
 
     response = schemas.DetailResponse(
-        user_info=user_db.to_response(), tweet_info=tweet_info, score=user_db.score
+        user_info=user_resp.user_info, tweet_info=tweet_info, score=user_resp.score
     )
     return response

--- a/app/services/report.py
+++ b/app/services/report.py
@@ -2,7 +2,7 @@ from typing import List
 
 from fastapi import Depends, HTTPException
 
-from app.models import Report
+from app.models import Report, TwitterUser
 from app.schemas.report import ReportResponse
 
 from .scrape import TwitterScraper
@@ -29,7 +29,10 @@ class ReportService:
         """
         report_db = Report.objects(twitter_id=twitter_id).first()
         if report_db is None:
-            user = self.twitter_scraper.get_user_by_id(twitter_id)
+            user = TwitterUser.objects(twitter_id=twitter_id).first()
+
+            if user is None:
+                raise HTTPException(404, "Twitter account not in database")
 
             report_db = Report(
                 twitter_id=user.twitter_id,

--- a/app/services/report.py
+++ b/app/services/report.py
@@ -32,7 +32,7 @@ class ReportService:
             user = TwitterUser.objects(twitter_id=twitter_id).first()
 
             if user is None:
-                raise HTTPException(404, "Twitter account not in database")
+                raise HTTPException(404, "Twitter account does not exist")
 
             report_db = Report(
                 twitter_id=user.twitter_id,

--- a/app/services/scrape.py
+++ b/app/services/scrape.py
@@ -30,9 +30,8 @@ class TwitterScraper:
         self._cache: TTLCache = TTLCache(maxsize=1024, ttl=settings.TWEEPY_CACHE_TTL)
 
     @cachedmethod(cache=_cache_func, key=_make_key("get_user_by_username"))
-    def get_user_by_username(self, username) -> tweepy.User:
-        """
-        Get details of Twitter user's information from given username.
+    def get_user_by_username(self, username: str) -> tweepy.User:
+        """Get details of Twitter user's information from given username.
 
         Args:
             username (string): The username of Twitter user got from input url.
@@ -67,8 +66,7 @@ class TwitterScraper:
             )
 
     def get_followers(self, followers_numbs):
-        """
-        Get list of Twitter user's followers.
+        """Get list of Twitter user's followers.
 
         Args:
             followers_numbs (int): Number of followers to get.
@@ -84,8 +82,7 @@ class TwitterScraper:
         return followers
 
     def get_followings(self, followings_numbs):
-        """
-        Get list of Twitter user's followings.
+        """Get list of Twitter user's followings.
 
         Args:
             followings_numbs (int): Number of followings to get.

--- a/app/services/scrape.py
+++ b/app/services/scrape.py
@@ -10,9 +10,6 @@ from fastapi import HTTPException
 from app.core.config import settings
 from app.models import Tweet, TwitterUser
 from app.schemas.tweet import TimeSeries
-from app.services.ml import ML
-
-ml_service = ML()
 
 
 def _make_key(method_name: str):
@@ -43,80 +40,32 @@ class TwitterScraper:
         Return:
             myitems (schemas.TwitterUser): TwitterUser informations.
         """
-        user_db = TwitterUser.objects(username=username).first()
-
-        if user_db is None:
-            print("This account is not exist in DB")
-            try:
-                user = self.api.get_user(screen_name=username)
-            except tweepy.NotFound:
-                raise HTTPException(
-                    status_code=404, detail=f"User account @{username} not found"
-                )
-            except tweepy.Forbidden:
-                raise HTTPException(
-                    status_code=403,
-                    detail=f"User account @{username} has been suspended",
-                )
-            else:
-                recent_tweets = self.get_tweet_info(user.id_str, settings.TWEETS_NUMBER)
-
-                user_db = TwitterUser(
-                    twitter_id=user.id_str,
-                    name=user.name,
-                    username=user.screen_name,
-                    created_at=user.created_at,
-                    followers_count=user.followers_count,
-                    followings_count=user.friends_count,
-                    verified=user.verified,
-                    avatar=user.profile_image_url,
-                    banner=getattr(user, "profile_banner_url", None),
-                    tweets=recent_tweets,
-                    score=ml_service.get_analysis_result(user.screen_name),
-                )
-
-                user_db.save()
-
-        return user_db
+        try:
+            return self.api.get_user(screen_name=username)
+        except tweepy.NotFound:
+            raise HTTPException(
+                status_code=404, detail=f"User account @{username} not found"
+            )
+        except tweepy.Forbidden:
+            raise HTTPException(
+                status_code=403,
+                detail=f"User account @{username} has been suspended",
+            )
 
     @cachedmethod(cache=_cache_func, key=_make_key("get_user_by_id"))
     def get_user_by_id(self, twitter_id: str) -> TwitterUser:
         """Get Twitter user information from given ID."""
-        user_db = TwitterUser.objects(twitter_id=twitter_id).first()
-
-        if user_db is None:
-            print("This account is not exist in DB")
-            try:
-                user = self.api.get_user(user_id=twitter_id)
-            except tweepy.NotFound:
-                raise HTTPException(
-                    status_code=404, detail=f"User with ID {twitter_id} not found"
-                )
-            except tweepy.Forbidden:
-                raise HTTPException(
-                    status_code=403,
-                    detail=f"User with ID {twitter_id} has been suspended",
-                )
-            else:
-                recent_tweets = self.get_tweet_info(user.id_str, settings.TWEETS_NUMBER)
-
-                user_db = TwitterUser(
-                    twitter_id=user.id_str,
-                    name=user.name,
-                    username=user.screen_name,
-                    created_at=user.created_at,
-                    followers_count=user.followers_count,
-                    followings_count=user.friends_count,
-                    verified=user.verified,
-                    avatar=user.profile_image_url,
-                    banner=getattr(user, "profile_banner_url", None),
-                    tweets=recent_tweets,
-                    score=ml_service.get_analysis_result(user.screen_name),
-                )
-
-                user_db.save()
-
-        return user_db
+        try:
+            return self.api.get_user(user_id=twitter_id)
+        except tweepy.NotFound:
+            raise HTTPException(
+                status_code=404, detail=f"User with ID {twitter_id} not found"
+            )
+        except tweepy.Forbidden:
+            raise HTTPException(
+                status_code=403,
+                detail=f"User with ID {twitter_id} has been suspended",
+            )
 
     def get_followers(self, followers_numbs):
         """

--- a/app/services/scrape.py
+++ b/app/services/scrape.py
@@ -2,7 +2,7 @@ from operator import attrgetter
 from typing import List, Tuple
 
 import pandas as pd
-import tweepy  # type: ignore
+import tweepy
 from cachetools import TTLCache, cachedmethod
 from cachetools.keys import hashkey
 from fastapi import HTTPException

--- a/app/tests/test_auth.py
+++ b/app/tests/test_auth.py
@@ -1,5 +1,3 @@
-from http import cookies
-
 import pytest
 
 from . import client
@@ -44,16 +42,3 @@ def test_logout_success(create_operator):
         "/auth/logout",
     )
     assert logout_response.status_code == 200
-
-
-def test_get_user_session_token():
-    issued_ids = []
-    for _ in range(20):
-        response = client.get(
-            "/auth/session-id", headers={"accept": "application/json"}
-        )
-        assert response.status_code == 200
-        cookie = cookies.SimpleCookie(response.headers["set-cookie"])
-        session_id = cookie["session_id"].value
-        assert session_id not in issued_ids
-        issued_ids.append(session_id)

--- a/app/tests/test_report.py
+++ b/app/tests/test_report.py
@@ -6,22 +6,15 @@ TWITTER_ID = "250831586"
 
 
 def test_user_report_twitter_account():
-    auth_response = client.get(
-        "/auth/session-id", headers={"accept": "application/json"}
-    )
-    assert auth_response.status_code == 200
-    cookie = cookies.SimpleCookie(auth_response.headers["set-cookie"])
-    session_id = cookie["session_id"].value
+    client.get("/api/check", params={"url": "https://twitter.com/TheRock"})
 
     report_response = client.post(
         f"/api/send-report/{TWITTER_ID}",
-        headers={"accept": "application/json", "Cookie": f"session_id={session_id}"},
     )
     assert report_response.status_code == 200
 
     re_report_response = client.post(
         f"/api/send-report/{TWITTER_ID}",
-        headers={"accept": "application/json", "Cookie": f"session_id={session_id}"},
     )
     assert re_report_response.status_code == 420
 


### PR DESCRIPTION
Currently, `TwitterScraper` have 2 responsibilities, fetch data from Twitter API and save data to database, which violates single-responsibility principle. This PR remove "save data to database" responsibility from `TwitterScraper`, and put it into endpoint.