### PR TITLE
Save session in database

### DIFF
--- a/app/api/report.py
+++ b/app/api/report.py
@@ -6,10 +6,11 @@ These are endpoints to handle
 import secrets
 from typing import List, Optional
 
-from fastapi import APIRouter, Cookie, Depends, Response
+from fastapi import APIRouter, Cookie, Depends, HttpException, Response
 
 from app import schemas
 from app.core.config import settings
+from app.models import AnonymousSession
 from app.services.auth import OperatorAuthHandler
 from app.services.report import ReportService
 
@@ -37,10 +38,15 @@ def send_report(
     session_id: Optional[str] = Cookie(None),
     report_service: ReportService = Depends(),
 ):
-    init_session = False
     if session_id is None:
         session_id = secrets.token_hex()
+        AnonymousSession(session_id=session_id).save()
         init_session = True
+    else:
+        session = AnonymousSession.objects(session_id=session_id).first()
+        if session is None:
+            raise HttpException(401, "Invalid session ID")
+        init_session = False
 
     report_service.add_report(twitter_user_id, reporter_id=session_id)
 

--- a/app/api/report.py
+++ b/app/api/report.py
@@ -6,7 +6,7 @@ These are endpoints to handle
 import secrets
 from typing import List, Optional
 
-from fastapi import APIRouter, Cookie, Depends, HttpException, Response
+from fastapi import APIRouter, Cookie, Depends, HTTPException, Response
 
 from app import schemas
 from app.core.config import settings
@@ -45,7 +45,7 @@ def send_report(
     else:
         session = AnonymousSession.objects(session_id=session_id).first()
         if session is None:
-            raise HttpException(401, "Invalid session ID")
+            raise HTTPException(401, "Invalid session ID")
         init_session = False
 
     report_service.add_report(twitter_user_id, reporter_id=session_id)

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,4 +1,5 @@
 from .operator import Operator
 from .report import Report
+from .session import AnonymousSession
 from .twitter import Tweet
 from .twitter import User as TwitterUser

--- a/app/models/session.py
+++ b/app/models/session.py
@@ -1,0 +1,8 @@
+from datetime import datetime
+
+from mongoengine import DateTimeField, Document, StringField
+
+
+class AnonymousSession(Document):
+    session_id: str = StringField(primary_key=True)
+    created_at: datetime = DateTimeField(default=datetime.utcnow)


### PR DESCRIPTION
Fix #30
- When creating new session ID, also save it to database.
- If send report request contains session ID, check if it exists in database.