### PR TITLE
Revert "Save session in database"

### DIFF
--- a/app/api/report.py
+++ b/app/api/report.py
@@ -6,11 +6,10 @@ These are endpoints to handle
 import secrets
 from typing import List, Optional
 
-from fastapi import APIRouter, Cookie, Depends, HTTPException, Response
+from fastapi import APIRouter, Cookie, Depends, Response
 
 from app import schemas
 from app.core.config import settings
-from app.models import AnonymousSession
 from app.services.auth import OperatorAuthHandler
 from app.services.report import ReportService
 
@@ -38,15 +37,10 @@ def send_report(
     session_id: Optional[str] = Cookie(None),
     report_service: ReportService = Depends(),
 ):
+    init_session = False
     if session_id is None:
         session_id = secrets.token_hex()
-        AnonymousSession(session_id=session_id).save()
         init_session = True
-    else:
-        session = AnonymousSession.objects(session_id=session_id).first()
-        if session is None:
-            raise HTTPException(401, "Invalid session ID")
-        init_session = False
 
     report_service.add_report(twitter_user_id, reporter_id=session_id)
 

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,5 +1,4 @@
 from .operator import Operator
 from .report import Report
-from .session import AnonymousSession
 from .twitter import Tweet
 from .twitter import User as TwitterUser

--- a/app/models/session.py
+++ b/app/models/session.py
@@ -1,8 +1,0 @@
-from datetime import datetime
-
-from mongoengine import DateTimeField, Document, StringField
-
-
-class AnonymousSession(Document):
-    session_id: str = StringField(primary_key=True)
-    created_at: datetime = DateTimeField(default=datetime.utcnow)

--- a/app/tests/test_report.py
+++ b/app/tests/test_report.py
@@ -39,19 +39,6 @@ class TestUserReport:
             assert Report.objects().count() == 1
             assert len(Report.objects()[0].reporters) == report_count
 
-        @pytest.mark.parametrize("session_id", ["", "    ", "wrong-session-id"])
-        def test_any_session_id(self, session_id):
-            # NOTE: this means that session_id can be self-set! :))
-            response = client.post(
-                f"/api/send-report/{TWITTER_ID}",
-                headers={
-                    "accept": "application/json",
-                    "Cookie": f"session_id={session_id}",
-                },
-            )
-            assert response.status_code == 200
-            pytest.skip("Will be fixed")
-
     class TestTwitterAccountNotChecked:
         def test_report_un_checked_account(self):
             response = client.post(


### PR DESCRIPTION
Reverts dirtyg2120/thesis-backend#32

After thinking again about this feature, I think this is pointless because sending arbitrary session token is no different from don't send any token and let backend generate a new token for you.